### PR TITLE
handle chars with "_" (underscore internally as bytecode)

### DIFF
--- a/R/qrVersionInfo.R
+++ b/R/qrVersionInfo.R
@@ -12,8 +12,8 @@
 qrVersionInfo <- function(dataString, ECLevel = c("L", "M", "Q", "H")) { #nolint
   ECLevel <- match.arg(ECLevel) #nolint
   # identify whether the data string is belongs to which category:
-  # Alphnumeric or Byte
-  if (length(grep("[a-z!?><;@#&()]", dataString)) == 0) {
+  # Alphanumeric or Byte
+  if (length(grep("[a-z!?><;@#&()_]", dataString)) == 0) {
     mode <- "0010" # Alphanumeric
     qrInfo <- head(
       qrCodeSpec[


### PR DESCRIPTION
Hi Thierry

First of all, thanks for making qrcode. We are using the package as a foundation to make QR codes and labels for soil sampling, measurements, spectroscopy etc.

Somehow qrcode not able to deal with "_" in the QR-Code strings. After some short reading and code inspection I did a quick fix to redirect character input containing "_" to the UTF8 byte stream pathway.

I have no clue if the fix is good or not, but maybe you can give me some hint if this is how you intended the logic of the package :-)
Thank you.
Cheers,
Philipp 